### PR TITLE
Fixes #2 deprecation warning regarding ansible_facts

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,13 +10,13 @@
     - name: Update apt cache on Debian systems.
       ansible.builtin.apt:
         update_cache: true
-      when: ansible_os_family == "Debian"
+      when: ansible_facts['os_family'] == "Debian"
 
     - name: Update pacman cache on Archlinux systems.
       pacman:
         update_cache: true
         upgrade: true
-      when: ansible_os_family == "Archlinux"
+      when: ansible_facts['os_family'] == "Archlinux"
 
   tasks:
     - name: "Include log2ram"

--- a/molecule/uninstall/converge.yml
+++ b/molecule/uninstall/converge.yml
@@ -9,13 +9,13 @@
     - name: Update apt cache on Debian systems.
       ansible.builtin.apt:
         update_cache: true
-      when: ansible_os_family == "Debian"
+      when: ansible_facts['os_family'] == "Debian"
 
     - name: Update pacman cache on Archlinux systems.
       pacman:
         update_cache: true
         upgrade: true
-      when: ansible_os_family == "Archlinux"
+      when: ansible_facts['os_family'] == "Archlinux"
 
   tasks:
     - name: Set correct variable to remove log2ram.

--- a/molecule/update/converge.yml
+++ b/molecule/update/converge.yml
@@ -10,13 +10,13 @@
     - name: Update apt cache on Debian systems.
       ansible.builtin.apt:
         update_cache: true
-      when: ansible_os_family == "Debian"
+      when: ansible_facts['os_family'] == "Debian"
 
     - name: Update pacman cache on Archlinux systems.
       pacman:
         update_cache: true
         upgrade: true
-      when: ansible_os_family == "Archlinux"
+      when: ansible_facts['os_family'] == "Archlinux"
 
   tasks:
     - name: Set correct variable to update log2ram.

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -1,26 +1,26 @@
 ---
 - name: Create downloads folder.
   ansible.builtin.file:
-    path: "{{ ansible_user_dir }}/.log2ram"
+    path: "{{ ansible_facts['user_dir'] }}/.log2ram"
     state: directory
     mode: 0700
 
 - name: Download log2ram archive.
   ansible.builtin.get_url:
     url: https://github.com/azlux/log2ram/archive/master.tar.gz
-    dest: "{{ ansible_user_dir }}/.log2ram/log2ram.tar.gz"
+    dest: "{{ ansible_facts['user_dir'] }}/.log2ram/log2ram.tar.gz"
     mode: 0600
 
 - name: Extract downloaded archive.
   ansible.builtin.unarchive:
-    src: "{{ ansible_user_dir }}/.log2ram/log2ram.tar.gz"
-    dest: "{{ ansible_user_dir }}/.log2ram/"
+    src: "{{ ansible_facts['user_dir'] }}/.log2ram/log2ram.tar.gz"
+    dest: "{{ ansible_facts['user_dir'] }}/.log2ram/"
     remote_src: true
     mode: 0644
 
 - name: Set execute permissions on the install script.
   ansible.builtin.file:
-    path: "{{ ansible_user_dir }}/.log2ram/log2ram-master/install.sh"
+    path: "{{ ansible_facts['user_dir'] }}/.log2ram/log2ram-master/install.sh"
     mode: u+x
 
 - name: Ensure rsync is installed if the 'log2ram_use_rsync' option is true.
@@ -32,7 +32,7 @@
 - name: Run the installation script.
   ansible.builtin.command:
     cmd: "sh install.sh"
-    chdir: "{{ ansible_user_dir }}/.log2ram/log2ram-master"
+    chdir: "{{ ansible_facts['user_dir'] }}/.log2ram/log2ram-master"
   changed_when: false
 
 - name: Reboot system after log2ram is installed.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   include_tasks: "{{ item }}"
   vars:
     files:
-      - "installation-{{ ansible_os_family }}.yml"
+      - "installation-{{ ansible_facts['os_family'] }}.yml"
       - installation.yml
   loop: "{{ q('first_found', files, errors='ignore' ) }}"
   when: log2ram_state == "install"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,25 +11,25 @@
 - name: Check if log2ram is installed (Debian-based systems).
   ansible.builtin.package_facts:
     manager: auto
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Check if log2ram is installed (Non-Debian systems).
   ansible.builtin.stat:
     path: /usr/local/bin/log2ram
   register: log2ram_is_installed
-  when: not ansible_os_family == "Debian"
+  when: not ansible_facts['os_family'] == "Debian"
 
 - name: Set fact about installed packages in Debian.
   ansible.builtin.set_fact:
     log2ram_installed: "{{ 'true' if 'log2ram' in ansible_facts.packages else 'false' }}"
   when:
-    - ansible_os_family == "Debian"
+    - ansible_facts['os_family'] == "Debian"
 
 - name: Set fact about installed packages in Non-Debian.
   ansible.builtin.set_fact:
     log2ram_installed: "{{ 'true' if log2ram_is_installed.stat['path'] is defined else 'false' }}"
   when:
-    - not ansible_os_family == "Debian"
+    - not ansible_facts['os_family'] == "Debian"
 
 - name: Configure log2ram.
   include_tasks: configuration.yml

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -11,13 +11,13 @@
     name: log2ram
     state: absent
     purge: true
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Make the uninstall script executable (Non-Debian systems).
   ansible.builtin.file:
     path: /usr/local/bin/uninstall-log2ram.sh
     mode: u+x
-  when: not ansible_os_family == "Debian"
+  when: not ansible_facts['os_family'] == "Debian"
 
 - name: Run the uninstall script (Non-Debian systems).
   ansible.builtin.command:
@@ -25,4 +25,4 @@
     chdir: /usr/local/bin
     warn: false
   changed_when: false
-  when: not ansible_os_family == "Debian"
+  when: not ansible_facts['os_family'] == "Debian"

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -3,7 +3,7 @@
   ansible.builtin.apt:
     name: log2ram
     state: latest
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Update log2ram on non-Debian systems.
   block:
@@ -14,9 +14,9 @@
 
     - name: Delete the old log2ram directory contents (Non-Debian systems).
       ansible.builtin.file:
-        path: "{{ ansible_user_dir }}/.log2ram"
+        path: "{{ ansible_facts['user_dir'] }}/.log2ram"
         state: absent
 
     - name: Proceed to installation (Non-Debian systems).
       include_tasks: installation.yml
-  when: not ansible_os_family == "Debian"
+  when: not ansible_facts['os_family'] == "Debian"


### PR DESCRIPTION
It is now deprecated to use `ansible_XYZ` and should instead use `ansible_facts['XYZ']`.
All occurences have been replaced and tested.